### PR TITLE
Fix #55: Add configurable SingularityPath for Apptainer support

### DIFF
--- a/docker/SlurmConfig.yaml
+++ b/docker/SlurmConfig.yaml
@@ -5,6 +5,7 @@ ScancelPath: "/usr/bin/scancel"
 SqueuePath: "/usr/bin/squeue"
 CommandPrefix: ""
 SingularityPrefix: ""
+SingularityPath: "singularity"
 ExportPodData: true
 DataRootFolder: ".local/interlink/jobs/"
 Namespace: "vk"

--- a/examples/config/SlurmConfig.yaml
+++ b/examples/config/SlurmConfig.yaml
@@ -5,6 +5,7 @@ ScancelPath: "/usr/bin/scancel"
 SqueuePath: "/usr/bin/squeue"
 CommandPrefix: ""
 SingularityPrefix: ""
+SingularityPath: "singularity"
 ExportPodData: true
 DataRootFolder: ".local/interlink/jobs/"
 Namespace: "vk"

--- a/pkg/slurm/Create.go
+++ b/pkg/slurm/Create.go
@@ -79,7 +79,7 @@ func (h *SidecarHandler) SubmitHandler(w http.ResponseWriter, r *http.Request) {
 			singularityOptions = singOpts
 		}
 
-		commstr1 := []string{"singularity", "exec", "--containall", "--nv", singularityMounts, singularityOptions}
+		commstr1 := []string{h.Config.SingularityPath, "exec", "--containall", "--nv", singularityMounts, singularityOptions}
 
 		image := ""
 

--- a/pkg/slurm/func.go
+++ b/pkg/slurm/func.go
@@ -69,6 +69,10 @@ func NewSlurmConfig() (SlurmConfig, error) {
 			SlurmConfigInst.Scancelpath = os.Getenv("SCANCELPATH")
 		}
 
+		if os.Getenv("SINGULARITYPATH") != "" {
+			SlurmConfigInst.SingularityPath = os.Getenv("SINGULARITYPATH")
+		}
+
 		if os.Getenv("TSOCKS") != "" {
 			if os.Getenv("TSOCKS") != "true" && os.Getenv("TSOCKS") != "false" {
 				fmt.Println("export TSOCKS as true or false")
@@ -89,6 +93,11 @@ func NewSlurmConfig() (SlurmConfig, error) {
 			}
 
 			SlurmConfigInst.Tsockspath = path
+		}
+
+		// Set default SingularityPath if not configured
+		if SlurmConfigInst.SingularityPath == "" {
+			SlurmConfigInst.SingularityPath = "singularity"
 		}
 
 		SlurmConfigInst.set = true

--- a/pkg/slurm/types.go
+++ b/pkg/slurm/types.go
@@ -19,6 +19,7 @@ type SlurmConfig struct {
 	VerboseLogging    bool   `yaml:"VerboseLogging"`
 	ErrorsOnlyLogging bool   `yaml:"ErrorsOnlyLogging"`
 	SingularityPrefix string `yaml:"SingularityPrefix"`
+	SingularityPath   string `yaml:"SingularityPath"`
 	set               bool
 }
 


### PR DESCRIPTION
- Add SingularityPath field to SlurmConfig struct
- Support SINGULARITYPATH environment variable override
- Default to \singularity\ for backward compatibility
- Replace hardcoded \singularity\ binary with configurable path
- Update example config files to document the new option

This allows users to specify alternative container runtimes like \apptainer\ or custom binary paths, resolving compatibility issues with systems that use Apptainer instead of Singularity.

🤖 Generated with [Claude Code](https://claude.ai/code)

<!--
A good PR should describe what benefit this brings to the repository.
Ideally, there is an existing issue which the PR address.

Please check the Contributing guide CONTRIBUTING.md for style requirements and
advice.
-->

# Summary

<!-- Describe in plain English what this PR does -->

---

<!-- Add, if any, the related issue here, e.g. #6 -->

**Related issue :**
