### PR TITLE
Add support for interlink.eu/wstunnel-client-commands annotation

### DIFF
--- a/pkg/slurm/prepare.go
+++ b/pkg/slurm/prepare.go
@@ -631,6 +631,10 @@ func produceSLURMScript(
 		prefix += "\n" + config.Commandprefix
 	}
 
+	if wstunnelClientCommands, ok := metadata.Annotations["interlink.eu/wstunnel-client-commands"]; ok {
+		prefix += "\n" + wstunnelClientCommands + " > wstunnel_client.log 2>&1 &"
+	}
+
 	if preExecAnnotations, ok := metadata.Annotations["slurm-job.vk.io/pre-exec"]; ok {
 		prefix += "\n" + preExecAnnotations
 	}


### PR DESCRIPTION
The annotation allows running wstunnel client commands in background with logs redirected to wstunnel_client.log before pre-exec commands.


**Related issue :** https://github.com/interlink-hq/interLink/pull/435 
