### PR TITLE
67 interlink slurm plugin ignores resourcesannotations generates invalid slurm script directives   cpus per task0

### DIFF
--- a/pkg/slurm/Create.go
+++ b/pkg/slurm/Create.go
@@ -22,25 +22,25 @@ import (
 )
 
 func parseMem(val string) (int64, error) {
-    re := regexp.MustCompile(`^(\d+)([KMG]?)$`)
-    m := re.FindStringSubmatch(val)
-    if len(m) != 3 {
-        return 0, errors.New("invalid memory format: " + val)
-    }
-    n, err := strconv.ParseInt(m[1], 10, 64)
-    if err != nil {
-        return 0, err
-    }
-    switch m[2] {
-    case "G":
-        return n * 1024 * 1024 * 1024, nil
-    case "M":
-        return n * 1024 * 1024, nil
-    case "K":
-        return n * 1024, nil
-    default:
-        return n, nil
-    }
+	re := regexp.MustCompile(`^(\d+)([KMG]?)$`)
+	m := re.FindStringSubmatch(val)
+	if len(m) != 3 {
+		return 0, errors.New("invalid memory format: " + val)
+	}
+	n, err := strconv.ParseInt(m[1], 10, 64)
+	if err != nil {
+		return 0, err
+	}
+	switch m[2] {
+	case "G":
+		return n * 1024 * 1024 * 1024, nil
+	case "M":
+		return n * 1024 * 1024, nil
+	case "K":
+		return n * 1024, nil
+	default:
+		return n, nil
+	}
 }
 
 // SubmitHandler generates and submits a SLURM batch script according to provided data.
@@ -94,45 +94,45 @@ func (h *SidecarHandler) SubmitHandler(w http.ResponseWriter, r *http.Request) {
 
 	// check if in the annotions slurm-job.knoc.io/flags there is --cpus-per-task= or --mem=, if so, use those values
 	raw, ok := metadata.Annotations["slurm-job.vk.io/flags"]
-    if !ok {
-        return
-    }
-    log.G(h.Ctx).Infof("Found slurm-job.vk.io/flags annotation: %q", raw)
+	if !ok {
+		return
+	}
+	log.G(h.Ctx).Infof("Found slurm-job.vk.io/flags annotation: %q", raw)
 
-    tokens := strings.Fields(raw)
-    for _, tok := range tokens {
-        // CPU
-        if strings.HasPrefix(tok, "--cpus-per-task=") {
-            val := strings.TrimPrefix(tok, "--cpus-per-task=")
-            cpu, err := strconv.ParseInt(val, 10, 64)
-            if err != nil {
-                log.G(h.Ctx).Errorf("Invalid --cpus-per-task value %q: %v", val, err)
-                continue
-            }
-            if cpu > 0 {
-                isDefaultCPU = false
-                cpuLimit = cpu
-                log.G(h.Ctx).Infof("Using CPU limit from annotation: %d", cpuLimit)
-            }
-            continue
-        }
+	tokens := strings.Fields(raw)
+	for _, tok := range tokens {
+		// CPU
+		if strings.HasPrefix(tok, "--cpus-per-task=") {
+			val := strings.TrimPrefix(tok, "--cpus-per-task=")
+			cpu, err := strconv.ParseInt(val, 10, 64)
+			if err != nil {
+				log.G(h.Ctx).Errorf("Invalid --cpus-per-task value %q: %v", val, err)
+				continue
+			}
+			if cpu > 0 {
+				isDefaultCPU = false
+				cpuLimit = cpu
+				log.G(h.Ctx).Infof("Using CPU limit from annotation: %d", cpuLimit)
+			}
+			continue
+		}
 
-        // Memory
-        if strings.HasPrefix(tok, "--mem=") {
-            val := strings.TrimPrefix(tok, "--mem=")
-            memBytes, err := parseMem(val)
-            if err != nil {
-                log.G(h.Ctx).Errorf("Invalid --mem value %q: %v", val, err)
-                continue
-            }
-            if memBytes > 0 {
-                isDefaultRam = false
-                memoryLimit = memBytes
-                log.G(h.Ctx).Infof("Using memory limit from annotation: %d bytes", memoryLimit)
-            }
-            continue
-        }
-    }
+		// Memory
+		if strings.HasPrefix(tok, "--mem=") {
+			val := strings.TrimPrefix(tok, "--mem=")
+			memBytes, err := parseMem(val)
+			if err != nil {
+				log.G(h.Ctx).Errorf("Invalid --mem value %q: %v", val, err)
+				continue
+			}
+			if memBytes > 0 {
+				isDefaultRam = false
+				memoryLimit = memBytes
+				log.G(h.Ctx).Infof("Using memory limit from annotation: %d bytes", memoryLimit)
+			}
+			continue
+		}
+	}
 
 	for i, container := range containers {
 		log.G(h.Ctx).Info("- Beginning script generation for container " + container.Name)
@@ -164,30 +164,30 @@ func (h *SidecarHandler) SubmitHandler(w http.ResponseWriter, r *http.Request) {
 
 		image := ""
 
-		cpuLimit, _ = container.Resources.Limits.Cpu().AsInt64()
-		memoryLimit, _ = container.Resources.Limits.Memory().AsInt64()
+		cpuLimitFromContainer, _ := container.Resources.Limits.Cpu().AsInt64()
+		memoryLimitFromContainer, _ := container.Resources.Limits.Memory().AsInt64()
 
-		if cpuLimit == 0 && isDefaultCPU {
+		if cpuLimitFromContainer == 0 && isDefaultCPU {
 			log.G(h.Ctx).Warning(errors.New("Max CPU resource not set for " + container.Name + ". Only 1 CPU will be used"))
-			resourceLimits.CPU += 1
+			resourceLimits.CPU = 1
 		} else {
-			if cpuLimit > resourceLimits.CPU && maxCPULimit < int(cpuLimit) {
-				log.G(h.Ctx).Info("Setting CPU limit to " + strconv.FormatInt(cpuLimit, 10))
-				resourceLimits.CPU = cpuLimit
-				maxCPULimit = int(cpuLimit)
+			if cpuLimitFromContainer > resourceLimits.CPU && maxCPULimit < int(cpuLimitFromContainer) {
+				log.G(h.Ctx).Info("Setting CPU limit to " + strconv.FormatInt(cpuLimitFromContainer, 10))
+				resourceLimits.CPU = cpuLimitFromContainer
+				maxCPULimit = int(cpuLimitFromContainer)
 				isDefaultCPU = false
 			}
 		}
 
-		if memoryLimit == 0 && isDefaultRam {
+		if memoryLimitFromContainer == 0 && isDefaultRam {
 			log.G(h.Ctx).Warning(errors.New("Max Memory resource not set for " + container.Name + ". Only 1MB will be used"))
-			resourceLimits.Memory += 1024 * 1024
+			resourceLimits.Memory = 1024 * 1024
 		} else {
 			//resourceLimits.Memory += MemoryLimit
-			if memoryLimit > resourceLimits.Memory && maxMemoryLimit < int(memoryLimit) {
-				log.G(h.Ctx).Info("Setting Memory limit to " + strconv.FormatInt(memoryLimit, 10))
-				resourceLimits.Memory = memoryLimit
-				maxMemoryLimit = int(memoryLimit)
+			if memoryLimitFromContainer > resourceLimits.Memory && maxMemoryLimit < int(memoryLimitFromContainer) {
+				log.G(h.Ctx).Info("Setting Memory limit to " + strconv.FormatInt(memoryLimitFromContainer, 10))
+				resourceLimits.Memory = memoryLimitFromContainer
+				maxMemoryLimit = int(memoryLimitFromContainer)
 				isDefaultRam = false
 			}
 		}

--- a/pkg/slurm/Create.go
+++ b/pkg/slurm/Create.go
@@ -173,7 +173,7 @@ func (h *SidecarHandler) SubmitHandler(w http.ResponseWriter, r *http.Request) {
 		} else {
 			if cpuLimitFromContainer > resourceLimits.CPU && maxCPULimit < int(cpuLimitFromContainer) {
 				log.G(h.Ctx).Info("Setting CPU limit to " + strconv.FormatInt(cpuLimitFromContainer, 10))
-				resourceLimits.CPU = cpuLimitFromContainer
+				cpuLimit = cpuLimitFromContainer
 				maxCPULimit = int(cpuLimitFromContainer)
 				isDefaultCPU = false
 			}
@@ -186,11 +186,14 @@ func (h *SidecarHandler) SubmitHandler(w http.ResponseWriter, r *http.Request) {
 			//resourceLimits.Memory += MemoryLimit
 			if memoryLimitFromContainer > resourceLimits.Memory && maxMemoryLimit < int(memoryLimitFromContainer) {
 				log.G(h.Ctx).Info("Setting Memory limit to " + strconv.FormatInt(memoryLimitFromContainer, 10))
-				resourceLimits.Memory = memoryLimitFromContainer
+				memoryLimit = memoryLimitFromContainer
 				maxMemoryLimit = int(memoryLimitFromContainer)
 				isDefaultRam = false
 			}
 		}
+
+		resourceLimits.CPU = cpuLimit
+		resourceLimits.Memory = memoryLimit
 
 		mounts, err := prepareMounts(spanCtx, h.Config, &data, &container, filesPath)
 		log.G(h.Ctx).Debug(mounts)

--- a/pkg/slurm/Create.go
+++ b/pkg/slurm/Create.go
@@ -134,7 +134,7 @@ func (h *SidecarHandler) SubmitHandler(w http.ResponseWriter, r *http.Request) {
 		cpuLimit, _ = container.Resources.Limits.Cpu().AsInt64()
 		memoryLimit, _ = container.Resources.Limits.Memory().AsInt64()
 
-		if cpuLimit == 0 {
+		if cpuLimit == 0 && isDefaultCPU {
 			log.G(h.Ctx).Warning(errors.New("Max CPU resource not set for " + container.Name + ". Only 1 CPU will be used"))
 			resourceLimits.CPU += 1
 		} else {
@@ -148,7 +148,7 @@ func (h *SidecarHandler) SubmitHandler(w http.ResponseWriter, r *http.Request) {
 			}
 		}
 
-		if memoryLimit == 0 {
+		if memoryLimit == 0 && isDefaultRam {
 			log.G(h.Ctx).Warning(errors.New("Max Memory resource not set for " + container.Name + ". Only 1MB will be used"))
 			resourceLimits.Memory += 1024 * 1024
 		} else {

--- a/pkg/slurm/Create.go
+++ b/pkg/slurm/Create.go
@@ -176,8 +176,6 @@ func (h *SidecarHandler) SubmitHandler(w http.ResponseWriter, r *http.Request) {
 				resourceLimits.CPU = cpuLimit
 				maxCPULimit = int(cpuLimit)
 				isDefaultCPU = false
-			} else {
-				log.G(h.Ctx).Info("Keeping CPU limit to " + strconv.FormatInt(resourceLimits.CPU, 10))
 			}
 		}
 
@@ -191,8 +189,6 @@ func (h *SidecarHandler) SubmitHandler(w http.ResponseWriter, r *http.Request) {
 				resourceLimits.Memory = memoryLimit
 				maxMemoryLimit = int(memoryLimit)
 				isDefaultRam = false
-			} else {
-				log.G(h.Ctx).Info("Keeping Memory limit to " + strconv.FormatInt(resourceLimits.Memory, 10))
 			}
 		}
 

--- a/pkg/slurm/Create.go
+++ b/pkg/slurm/Create.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"io"
+	"math"
 	"net/http"
 	"os"
 	"strconv"
@@ -92,48 +93,6 @@ func (h *SidecarHandler) SubmitHandler(w http.ResponseWriter, r *http.Request) {
 	cpuLimit := int64(0)
 	memoryLimit := int64(0)
 
-	// check if in the annotions slurm-job.knoc.io/flags there is --cpus-per-task= or --mem=, if so, use those values
-	// raw, ok := metadata.Annotations["slurm-job.vk.io/flags"]
-	// if !ok {
-	// 	return
-	// }
-	// log.G(h.Ctx).Infof("Found slurm-job.vk.io/flags annotation: %q", raw)
-
-	// tokens := strings.Fields(raw)
-	// for _, tok := range tokens {
-	// 	// CPU
-	// 	if strings.HasPrefix(tok, "--cpus-per-task=") {
-	// 		val := strings.TrimPrefix(tok, "--cpus-per-task=")
-	// 		cpu, err := strconv.ParseInt(val, 10, 64)
-	// 		if err != nil {
-	// 			log.G(h.Ctx).Errorf("Invalid --cpus-per-task value %q: %v", val, err)
-	// 			continue
-	// 		}
-	// 		if cpu > 0 {
-	// 			isDefaultCPU = false
-	// 			cpuLimit = cpu
-	// 			log.G(h.Ctx).Infof("Using CPU limit from annotation: %d", cpuLimit)
-	// 		}
-	// 		continue
-	// 	}
-
-	// 	// Memory
-	// 	if strings.HasPrefix(tok, "--mem=") {
-	// 		val := strings.TrimPrefix(tok, "--mem=")
-	// 		memBytes, err := parseMem(val)
-	// 		if err != nil {
-	// 			log.G(h.Ctx).Errorf("Invalid --mem value %q: %v", val, err)
-	// 			continue
-	// 		}
-	// 		if memBytes > 0 {
-	// 			isDefaultRam = false
-	// 			memoryLimit = memBytes
-	// 			log.G(h.Ctx).Infof("Using memory limit from annotation: %d bytes", memoryLimit)
-	// 		}
-	// 		continue
-	// 	}
-	// }
-
 	for i, container := range containers {
 		log.G(h.Ctx).Info("- Beginning script generation for container " + container.Name)
 
@@ -164,8 +123,10 @@ func (h *SidecarHandler) SubmitHandler(w http.ResponseWriter, r *http.Request) {
 
 		image := ""
 
-		cpuLimitFromContainer, _ := container.Resources.Limits.Cpu().AsInt64()
+		cpuLimitFloat := container.Resources.Limits.Cpu().AsApproximateFloat64()
 		memoryLimitFromContainer, _ := container.Resources.Limits.Memory().AsInt64()
+
+		cpuLimitFromContainer := int64(math.Ceil(cpuLimitFloat))
 
 		if cpuLimitFromContainer == 0 && isDefaultCPU {
 			log.G(h.Ctx).Warning(errors.New("Max CPU resource not set for " + container.Name + ". Only 1 CPU will be used"))
@@ -183,7 +144,6 @@ func (h *SidecarHandler) SubmitHandler(w http.ResponseWriter, r *http.Request) {
 			log.G(h.Ctx).Warning(errors.New("Max Memory resource not set for " + container.Name + ". Only 1MB will be used"))
 			resourceLimits.Memory = 1024 * 1024
 		} else {
-			//resourceLimits.Memory += MemoryLimit
 			if memoryLimitFromContainer > resourceLimits.Memory && maxMemoryLimit < int(memoryLimitFromContainer) {
 				log.G(h.Ctx).Info("Setting Memory limit to " + strconv.FormatInt(memoryLimitFromContainer, 10))
 				memoryLimit = memoryLimitFromContainer

--- a/pkg/slurm/Create.go
+++ b/pkg/slurm/Create.go
@@ -93,46 +93,46 @@ func (h *SidecarHandler) SubmitHandler(w http.ResponseWriter, r *http.Request) {
 	memoryLimit := int64(0)
 
 	// check if in the annotions slurm-job.knoc.io/flags there is --cpus-per-task= or --mem=, if so, use those values
-	raw, ok := metadata.Annotations["slurm-job.vk.io/flags"]
-	if !ok {
-		return
-	}
-	log.G(h.Ctx).Infof("Found slurm-job.vk.io/flags annotation: %q", raw)
+	// raw, ok := metadata.Annotations["slurm-job.vk.io/flags"]
+	// if !ok {
+	// 	return
+	// }
+	// log.G(h.Ctx).Infof("Found slurm-job.vk.io/flags annotation: %q", raw)
 
-	tokens := strings.Fields(raw)
-	for _, tok := range tokens {
-		// CPU
-		if strings.HasPrefix(tok, "--cpus-per-task=") {
-			val := strings.TrimPrefix(tok, "--cpus-per-task=")
-			cpu, err := strconv.ParseInt(val, 10, 64)
-			if err != nil {
-				log.G(h.Ctx).Errorf("Invalid --cpus-per-task value %q: %v", val, err)
-				continue
-			}
-			if cpu > 0 {
-				isDefaultCPU = false
-				cpuLimit = cpu
-				log.G(h.Ctx).Infof("Using CPU limit from annotation: %d", cpuLimit)
-			}
-			continue
-		}
+	// tokens := strings.Fields(raw)
+	// for _, tok := range tokens {
+	// 	// CPU
+	// 	if strings.HasPrefix(tok, "--cpus-per-task=") {
+	// 		val := strings.TrimPrefix(tok, "--cpus-per-task=")
+	// 		cpu, err := strconv.ParseInt(val, 10, 64)
+	// 		if err != nil {
+	// 			log.G(h.Ctx).Errorf("Invalid --cpus-per-task value %q: %v", val, err)
+	// 			continue
+	// 		}
+	// 		if cpu > 0 {
+	// 			isDefaultCPU = false
+	// 			cpuLimit = cpu
+	// 			log.G(h.Ctx).Infof("Using CPU limit from annotation: %d", cpuLimit)
+	// 		}
+	// 		continue
+	// 	}
 
-		// Memory
-		if strings.HasPrefix(tok, "--mem=") {
-			val := strings.TrimPrefix(tok, "--mem=")
-			memBytes, err := parseMem(val)
-			if err != nil {
-				log.G(h.Ctx).Errorf("Invalid --mem value %q: %v", val, err)
-				continue
-			}
-			if memBytes > 0 {
-				isDefaultRam = false
-				memoryLimit = memBytes
-				log.G(h.Ctx).Infof("Using memory limit from annotation: %d bytes", memoryLimit)
-			}
-			continue
-		}
-	}
+	// 	// Memory
+	// 	if strings.HasPrefix(tok, "--mem=") {
+	// 		val := strings.TrimPrefix(tok, "--mem=")
+	// 		memBytes, err := parseMem(val)
+	// 		if err != nil {
+	// 			log.G(h.Ctx).Errorf("Invalid --mem value %q: %v", val, err)
+	// 			continue
+	// 		}
+	// 		if memBytes > 0 {
+	// 			isDefaultRam = false
+	// 			memoryLimit = memBytes
+	// 			log.G(h.Ctx).Infof("Using memory limit from annotation: %d bytes", memoryLimit)
+	// 		}
+	// 		continue
+	// 	}
+	// }
 
 	for i, container := range containers {
 		log.G(h.Ctx).Info("- Beginning script generation for container " + container.Name)

--- a/pkg/slurm/Create.go
+++ b/pkg/slurm/Create.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"errors"
 	"io"
-	"math"
 	"net/http"
 	"os"
 	"strconv"
@@ -165,10 +164,8 @@ func (h *SidecarHandler) SubmitHandler(w http.ResponseWriter, r *http.Request) {
 
 		image := ""
 
-		cpuLimitFloat := container.Resources.Limits.Cpu().AsApproximateFloat64()
+		cpuLimitFromContainer, _ := container.Resources.Limits.Cpu().AsInt64()
 		memoryLimitFromContainer, _ := container.Resources.Limits.Memory().AsInt64()
-
-		cpuLimitFromContainer := int64(math.Ceil(cpuLimitFloat))
 
 		if cpuLimitFromContainer == 0 && isDefaultCPU {
 			log.G(h.Ctx).Warning(errors.New("Max CPU resource not set for " + container.Name + ". Only 1 CPU will be used"))
@@ -186,6 +183,7 @@ func (h *SidecarHandler) SubmitHandler(w http.ResponseWriter, r *http.Request) {
 			log.G(h.Ctx).Warning(errors.New("Max Memory resource not set for " + container.Name + ". Only 1MB will be used"))
 			resourceLimits.Memory = 1024 * 1024
 		} else {
+			//resourceLimits.Memory += MemoryLimit
 			if memoryLimitFromContainer > resourceLimits.Memory && maxMemoryLimit < int(memoryLimitFromContainer) {
 				log.G(h.Ctx).Info("Setting Memory limit to " + strconv.FormatInt(memoryLimitFromContainer, 10))
 				memoryLimit = memoryLimitFromContainer

--- a/pkg/slurm/prepare.go
+++ b/pkg/slurm/prepare.go
@@ -529,6 +529,8 @@ func produceSLURMScript(
 	metadata metav1.ObjectMeta,
 	commands []SingularityCommand,
 	resourceLimits ResourceLimits,
+	isDefaultCPU bool,
+	isDefaultRam bool,
 ) (string, error) {
 	start := time.Now().UnixMicro()
 	span := trace.SpanFromContext(Ctx)
@@ -576,8 +578,13 @@ func produceSLURMScript(
 		}
 	}
 
-	sbatchFlagsFromArgo = append(sbatchFlagsFromArgo, "--mem="+strconv.FormatInt(resourceLimits.Memory/1024/1024, 10))
-	sbatchFlagsFromArgo = append(sbatchFlagsFromArgo, "--cpus-per-task="+strconv.FormatInt(resourceLimits.CPU, 10))
+	if !isDefaultCPU {
+		sbatchFlagsFromArgo = append(sbatchFlagsFromArgo, "--cpus-per-task="+strconv.FormatInt(resourceLimits.CPU, 10))
+	}
+
+	if !isDefaultRam {
+		sbatchFlagsFromArgo = append(sbatchFlagsFromArgo, "--mem="+strconv.FormatInt(resourceLimits.Memory/1024/1024, 10))
+	}
 
 	for _, slurmFlag := range sbatchFlagsFromArgo {
 		sbatchFlagsAsString += "\n#SBATCH " + slurmFlag

--- a/pkg/slurm/prepare.go
+++ b/pkg/slurm/prepare.go
@@ -605,6 +605,14 @@ func produceSLURMScript(
 		}
 
 		sbatchFlagsFromArgo = strings.Split(slurmFlags, " ")
+
+		// Remove empty strings from the slice
+		for i := 0; i < len(sbatchFlagsFromArgo); i++ {
+			if sbatchFlagsFromArgo[i] == "" {
+				sbatchFlagsFromArgo = append(sbatchFlagsFromArgo[:i], sbatchFlagsFromArgo[i+1:]...)
+				i-- // Adjust index after removal
+			}
+		}
 	}
 
 	// if raw, ok := metadata.Annotations["slurm-job.vk.io/flags"]; ok {

--- a/pkg/slurm/prepare.go
+++ b/pkg/slurm/prepare.go
@@ -594,6 +594,9 @@ func produceSLURMScript(
 			re = regexp.MustCompile(`--mem\s+\d+`)
 			slurmFlags = re.ReplaceAllString(slurmFlags, "")
 		}
+		// log the flags
+		log.G(Ctx).Info("Using SLURM flags from annotations: ", slurmFlags)
+		// split the flags by space and remove empty strings
 		sbatchFlagsFromArgo = strings.Split(slurmFlags, " ")
 	}
 	if mpiFlags, ok := metadata.Annotations["slurm-job.vk.io/mpi-flags"]; ok {

--- a/pkg/slurm/prepare.go
+++ b/pkg/slurm/prepare.go
@@ -585,19 +585,19 @@ func produceSLURMScript(
 
 	var sbatchFlagsFromArgo []string
 	sbatchFlagsAsString := ""
-	if slurmFlags, ok := metadata.Annotations["slurm-job.vk.io/flags"]; ok {
-		// ignore the --cpus-per-task and --mem flags, since they have been set already
-		if strings.Contains(slurmFlags, "--cpus-per-task") || strings.Contains(slurmFlags, "--mem") {
+	if raw, ok := metadata.Annotations["slurm-job.vk.io/flags"]; ok {
+		slurmFlags := raw
+
+		re := regexp.MustCompile(`--(?:cpus-per-task|mem)(?:[ =]\S+)?`)
+		if re.MatchString(slurmFlags) {
 			log.G(Ctx).Info("Ignoring --cpus-per-task and --mem flags from annotations, since they are set already")
-			re := regexp.MustCompile(`--cpus-per-task\s+\d+`)
-			slurmFlags = re.ReplaceAllString(slurmFlags, "")
-			re = regexp.MustCompile(`--mem\s+\d+`)
 			slurmFlags = re.ReplaceAllString(slurmFlags, "")
 		}
-		// log the flags
-		log.G(Ctx).Info("Using SLURM flags from annotations: ", slurmFlags)
-		// split the flags by space and remove empty strings
-		sbatchFlagsFromArgo = strings.Split(slurmFlags, " ")
+
+		slurmFlags = strings.TrimSpace(slurmFlags)
+		sbatchFlagsFromArgo = strings.Fields(slurmFlags)
+
+		log.G(Ctx).Info("Using SLURM flags from annotations:", sbatchFlagsFromArgo)
 	}
 	if mpiFlags, ok := metadata.Annotations["slurm-job.vk.io/mpi-flags"]; ok {
 		if mpiFlags != "true" {

--- a/pkg/slurm/prepare.go
+++ b/pkg/slurm/prepare.go
@@ -599,10 +599,16 @@ func produceSLURMScript(
 
 	if !isDefaultCPU {
 		sbatchFlagsFromArgo = append(sbatchFlagsFromArgo, "--cpus-per-task="+strconv.FormatInt(resourceLimits.CPU, 10))
+	} else {
+		log.G(Ctx).Info("Using default CPU limit of 1")
+		sbatchFlagsFromArgo = append(sbatchFlagsFromArgo, "--cpus-per-task=1")
 	}
 
 	if !isDefaultRam {
 		sbatchFlagsFromArgo = append(sbatchFlagsFromArgo, "--mem="+strconv.FormatInt(resourceLimits.Memory/1024/1024, 10))
+	} else {
+		log.G(Ctx).Info("Using default Memory limit of 1MB")
+		sbatchFlagsFromArgo = append(sbatchFlagsFromArgo, "--mem=1")
 	}
 
 	for _, slurmFlag := range sbatchFlagsFromArgo {

--- a/pkg/slurm/prepare.go
+++ b/pkg/slurm/prepare.go
@@ -586,6 +586,14 @@ func produceSLURMScript(
 	var sbatchFlagsFromArgo []string
 	sbatchFlagsAsString := ""
 	if slurmFlags, ok := metadata.Annotations["slurm-job.vk.io/flags"]; ok {
+		// ignore the --cpus-per-task and --mem flags, since they have been set already
+		if strings.Contains(slurmFlags, "--cpus-per-task") || strings.Contains(slurmFlags, "--mem") {
+			log.G(Ctx).Info("Ignoring --cpus-per-task and --mem flags from annotations, since they are set already")
+			re := regexp.MustCompile(`--cpus-per-task\s+\d+`)
+			slurmFlags = re.ReplaceAllString(slurmFlags, "")
+			re = regexp.MustCompile(`--mem\s+\d+`)
+			slurmFlags = re.ReplaceAllString(slurmFlags, "")
+		}
 		sbatchFlagsFromArgo = strings.Split(slurmFlags, " ")
 	}
 	if mpiFlags, ok := metadata.Annotations["slurm-job.vk.io/mpi-flags"]; ok {

--- a/pkg/slurm/prepare.go
+++ b/pkg/slurm/prepare.go
@@ -610,6 +610,7 @@ func produceSLURMScript(
 
 	if !isDefaultCPU {
 		sbatchFlagsFromArgo = append(sbatchFlagsFromArgo, "--cpus-per-task="+strconv.FormatInt(resourceLimits.CPU, 10))
+		log.G(Ctx).Info("Using CPU limit of " + strconv.FormatInt(resourceLimits.CPU, 10))
 	} else {
 		log.G(Ctx).Info("Using default CPU limit of 1")
 		sbatchFlagsFromArgo = append(sbatchFlagsFromArgo, "--cpus-per-task=1")


### PR DESCRIPTION
This PR updates the Slurm plugin to handle resource requests directly. Pods can now specify their resource requirements either through standard Kubernetes ```resources.requests``` fields or via ```annotations```. If both methods are used, the values defined in ```resources.requests``` take precedence over those specified in annotations. If more containers are specified the highest resources are considered.

The following pod have been tried as tests:

```
apiVersion: v1
kind: Pod
metadata:
  name: res-test-0
  namespace: interlink
  annotations: {"slurm-job.vk.io/flags": "--job-name=test-pod"}

spec:
  restartPolicy: Never
  nodeSelector:
    kubernetes.io/hostname: vk-podman-slurm

  containers:
  - name: cn0
    image: docker://ghcr.io/grycap/cowsay
    command: ["/bin/echo"]
    args: ["container 0"]
    imagePullPolicy: Always
    resources:
      limits:
        memory: "2G"
        cpu: "1"

  - name: cn1
    image: docker://ghcr.io/grycap/cowsay
    command: ["/bin/echo"]
    args: ["container 1"]
    imagePullPolicy: Always

  dnsPolicy: ClusterFirst

  tolerations:
    - key: virtual-node.interlink/no-schedule
      operator: Exists
      effect: NoSchedule
```

```
# in this case the resources limits take in consideration are the one of the first containers

apiVersion: v1
kind: Pod
metadata:
  name: res-test-2
  namespace: interlink
  # --cpus-per-task=4
  annotations: {"slurm-job.vk.io/flags": "--job-name=test-pod --cpus-per-task=4 --mem=200"}

spec:
  restartPolicy: Never
  nodeSelector:
    kubernetes.io/hostname: vk-podman-slurm

  containers:
  - name: cn0
    image: docker://ghcr.io/grycap/cowsay
    command: ["/bin/echo"]
    args: ["container 0"]
    imagePullPolicy: Always
    resources:
      limits:
        memory: "2G"
        cpu: "3"

  - name: cn1
    image: docker://ghcr.io/grycap/cowsay
    command: ["/bin/echo"]
    args: ["container 1"]
    imagePullPolicy: Always
    resources:
      limits:
        memory: "3Gi"
        cpu: "1"

  dnsPolicy: ClusterFirst

  tolerations:
    - key: virtual-node.interlink/no-schedule
      operator: Exists
      effect: NoSchedule
```

```
# in this case the cpus-per-task and mem are considered

apiVersion: v1
kind: Pod
metadata:
  name: res-test-3
  namespace: interlink
  annotations: {"slurm-job.vk.io/flags": "--job-name=test-pod --cpus-per-task=4 --mem=200"}

spec:
  restartPolicy: Never
  nodeSelector:
    kubernetes.io/hostname: vk-podman-slurm

  containers:
  - name: cn0
    image: docker://ghcr.io/grycap/cowsay
    command: ["/bin/echo"]
    args: ["container 0"]
    imagePullPolicy: Always
    #resources:
    #  limits:
    #    memory: "2G"
    #    cpu: "3"
       # cpu: "250m"

  - name: cn1
    image: docker://ghcr.io/grycap/cowsay
    command: ["/bin/echo"]
    args: ["container 1"]
    imagePullPolicy: Always
    #resources:
    #  limits:
    #    memory: "3Gi"
    #    cpu: "1"

  dnsPolicy: ClusterFirst

  tolerations:
    - key: virtual-node.interlink/no-schedule
      operator: Exists
      effect: NoSchedule
```