### PR TITLE
Il 0.3.7to0.5.2 end to end regressions

### DIFF
--- a/pkg/slurm/func.go
+++ b/pkg/slurm/func.go
@@ -111,6 +111,10 @@ func NewSlurmConfig() (SlurmConfig, error) {
 		}
 
 		SlurmConfigInst.set = true
+
+		if len(SlurmConfigInst.SingularityDefaultOptions) == 0 {
+			SlurmConfigInst.SingularityDefaultOptions = []string{"--nv", "--no-eval", "--containall"}
+		}
 	}
 	return SlurmConfigInst, nil
 }

--- a/pkg/slurm/prepare.go
+++ b/pkg/slurm/prepare.go
@@ -722,7 +722,7 @@ waitCtns() {
     exitCode="$?"
     printf "%s\n" "${exitCode}" > "${workingPath}/run-${ctn}.status"
     printf "%s\n" "$(date -Is --utc) Container ${ctn} pid ${pid} ended with status ${exitCode}."
-	waitFileExist "${workingPath}/${ctn}.status"
+	waitFileExist "${workingPath}/run-${ctn}.status"
   done
   # Compatibility with jobScript, read the result of conainer .status files
   for filestatus in $(ls *.status) ; do

--- a/pkg/slurm/types.go
+++ b/pkg/slurm/types.go
@@ -20,7 +20,7 @@ type SlurmConfig struct {
 	BashPath                  string   `yaml:"BashPath"`
 	VerboseLogging            bool     `yaml:"VerboseLogging"`
 	ErrorsOnlyLogging         bool     `yaml:"ErrorsOnlyLogging"`
-	SingularityDefaultOptions []string `yaml:"SingularityDefaultOptions" default:"[\"--nv\", \"--no-eval\", \"--containall\"]"`
+	SingularityDefaultOptions []string `yaml:"SingularityDefaultOptions"`
 	SingularityPrefix         string   `yaml:"SingularityPrefix"`
 	SingularityPath           string   `yaml:"SingularityPath"`
 	set                       bool


### PR DESCRIPTION
<!--
A good PR should describe what benefit this brings to the repository.
Ideally, there is an existing issue which the PR address.

Please check the Contributing guide CONTRIBUTING.md for style requirements and
advice.
-->

# Summary
After upgrading from InterLink (and Slurm plugin) from 0.3.7 (patched version) to >= 0.5.2-pre2, a few regressions arised:
* `job.sh` didn't wait for the new file name `run-[ctn]`. Fixed.
* Singularity default options has been moved to struct default tag, which is not compatible with array. Fixed.


<!-- Describe in plain English what this PR does -->

---

<!-- Add, if any, the related issue here, e.g. #6 -->

**Related issue :**
