### PR TITLE
add tracability pod job id

### DIFF
--- a/pkg/slurm/Create.go
+++ b/pkg/slurm/Create.go
@@ -216,7 +216,7 @@ func (h *SidecarHandler) SubmitHandler(w http.ResponseWriter, r *http.Request) {
 		attribute.Int64("job.limits.memory", resourceLimits.Memory),
 	)
 
-	path, err := produceSLURMScript(spanCtx, h.Config, string(data.Pod.UID), filesPath, metadata, singularity_command_pod, resourceLimits, isDefaultCPU, isDefaultRam)
+	path, err := produceSLURMScript(spanCtx, h.Config, data.Pod, filesPath, metadata, singularity_command_pod, resourceLimits, isDefaultCPU, isDefaultRam)
 	if err != nil {
 		log.G(h.Ctx).Error(err)
 		os.RemoveAll(filesPath)

--- a/pkg/slurm/prepare.go
+++ b/pkg/slurm/prepare.go
@@ -809,12 +809,12 @@ highestExitCode=0
 	stringToBeWritten.WriteString(sbatch_common_funcs_macros)
 
 	// Adding tracability between pod and job ID.
-	stringToBeWritten.WriteString("\necho \"This pod ")
+	stringToBeWritten.WriteString("\nprintf '%s\n' \"This pod ")
 	stringToBeWritten.WriteString(pod.Name)
 	stringToBeWritten.WriteString("/")
 	stringToBeWritten.WriteString(podUID)
 	stringToBeWritten.WriteString(" has been submitted to SLURM node ${SLURMD_NODENAME}.\"")
-	stringToBeWritten.WriteString("\necho \"To get more info, please run: scontrol show job ${SLURM_JOBID}.\"")
+	stringToBeWritten.WriteString("\nprintf '%s\n' \"To get more info, please run: scontrol show job ${SLURM_JOBID}.\"")
 
 	// Adding the workingPath as variable.
 	stringToBeWritten.WriteString("\nexport workingPath=")

--- a/pkg/slurm/prepare.go
+++ b/pkg/slurm/prepare.go
@@ -526,7 +526,7 @@ func prepareMounts(
 func produceSLURMScript(
 	Ctx context.Context,
 	config SlurmConfig,
-	podUID string,
+	pod v1.Pod,
 	path string,
 	metadata metav1.ObjectMeta,
 	commands []SingularityCommand,
@@ -537,6 +537,8 @@ func produceSLURMScript(
 	start := time.Now().UnixMicro()
 	span := trace.SpanFromContext(Ctx)
 	span.AddEvent("Producing SLURM script")
+
+	podUID := string(pod.UID)
 
 	log.G(Ctx).Info("-- Creating file for the Slurm script")
 	prefix = ""
@@ -805,6 +807,14 @@ highestExitCode=0
 
 	`
 	stringToBeWritten.WriteString(sbatch_common_funcs_macros)
+
+	// Adding tracability between pod and job ID.
+	stringToBeWritten.WriteString("\necho \"This pod ")
+	stringToBeWritten.WriteString(pod.Name)
+	stringToBeWritten.WriteString("/")
+	stringToBeWritten.WriteString(podUID)
+	stringToBeWritten.WriteString(" has been submitted to SLURM node ${SLURMD_NODENAME}.\"")
+	stringToBeWritten.WriteString("\necho \"To get more info, please run: scontrol show job ${SLURM_JOBID}.\"")
 
 	// Adding the workingPath as variable.
 	stringToBeWritten.WriteString("\nexport workingPath=")


### PR DESCRIPTION
<!--
A good PR should describe what benefit this brings to the repository.
Ideally, there is an existing issue which the PR address.

Please check the Contributing guide CONTRIBUTING.md for style requirements and
advice.
-->

# Summary

<!-- Describe in plain English what this PR does -->

Fix #81 . In a job log `job.out`, this gives:
```
This pod my-pod-wd99j-3971034915/863930c9-bb5e-4b6e-92a5-c221f918c6af has been submitted to SLURM node hpc-node-1234.
To get more info, please run: scontrol show job 42540740.
```
---

<!-- Add, if any, the related issue here, e.g. #6 -->

**Related issue :**
#81