### PR TITLE
Fix compilation errors in probe script generation

### DIFF
--- a/pkg/slurm/probes.go
+++ b/pkg/slurm/probes.go
@@ -140,17 +140,18 @@ executeExecProbe() {
     local container_name="$2"
     shift 2
     local command=("$@")
-    
+
     # Use singularity exec to run the command inside the container
-    `, imageName))
+    `)
 	scriptBuilder.WriteString(fmt.Sprintf(`"%s" exec`, config.SingularityPath))
 	for _, opt := range config.SingularityDefaultOptions {
 		scriptBuilder.WriteString(fmt.Sprintf(` "%s"`, opt))
 	}
 	scriptBuilder.WriteString(fmt.Sprintf(` "%s" timeout "${timeout}" "${command[@]}"
     return $?
-}
+}`, imageName))
 
+	scriptBuilder.WriteString(`
 runProbe() {
     local probe_type="$1"
     local container_name="$2"
@@ -230,7 +231,7 @@ runProbe() {
     return 0
 }
 
-`, imageName))
+`)
 
 	// Generate readiness probe calls
 	for i, probe := range readinessProbes {


### PR DESCRIPTION
## Summary
- Fixed syntax errors in `pkg/slurm/probes.go` that were preventing compilation
- Corrected bash script template generation issues in probe execution functions

## Changes
- Fixed dangling `imageName` parameter in bash script template at line 145
- Added missing string literal wrapper around `runProbe()` bash function
- Removed extra `imageName` parameter from template that didn't expect it

## Test plan
- [x] Code compiles successfully with `go build`
- [x] No syntax errors in the generated bash script templates
- [x] Probe script generation logic remains functionally unchanged

🤖 Generated with [Claude Code](https://claude.ai/code)